### PR TITLE
Block double-middle strategy

### DIFF
--- a/TicTacToe.py
+++ b/TicTacToe.py
@@ -205,7 +205,8 @@ class TicTacToe:
 			for i in option:
 				score_keeper[self.board[i[0]][i[1]]] += 1
 
-			# If there are two bot icons set to win and a blank space available, take the blank space to win the game
+			# If there are two bot icons set to win and a blank space available,
+			# take the blank space to win the game
 			if score_keeper[bot_icon] == 2 and score_keeper[self.BLANK_POS] == 1:
 				for i in option:
 					if self.board[i[0]][i[1]] == self.BLANK_POS:
@@ -240,7 +241,28 @@ class TicTacToe:
 
 		# Check for edge-cases (that happen on turn 3)
 		if bot_icon == self.PLAYER_1 and len(self.move_history) == 3:
-			# Check for first edge-case: see board [[X, , ], [ ,X, ], [ , ,O]]
+			# Check for Double-Middle edge case: see board [[ ,X, ], [X,O, ], [ , ,O]]
+			# If player 0 plays in board[0][0], they are guaranteed a win scenario.  Avoid this trap.
+			if ((opp_move_1 := self.move_history[0])[0] + opp_move_1[1]) % 2 == 1:
+				# In this scenario, both of the user's moves are odd...
+				if ((opp_move_2 := self.move_history[2])[0] + opp_move_2[1]) % 2 == 1:
+					# ... and do not share a row or column.
+					if (opp_move_1[0] != opp_move_2[0]) and (opp_move_1[1] != opp_move_2[1]):
+						# Avoid the middle, and a second space that is calculated with MATH!
+						space_to_avoid = (
+							3 - (opp_move_1[0] + opp_move_2[0]),
+							3 - (opp_move_1[1] + opp_move_2[1])
+						)
+						while not valid_move:
+							# choose a corner at random
+							row = random.choice((0, 2))
+							col = random.choice((0, 2))
+							valid_move = self.checkValidMove(row, col)
+							# but avoid that corner that we calculated with MATH!
+							if (row, col) == space_to_avoid:
+								valid_move = False
+						return row, col
+			# Check for The Diagonal Dagger edge-case: see board [[X, , ], [ ,X, ], [ , ,O]]
 			# In this (or rotated) situation, bot should select a corner space
 			if self.board[1][1] == self.PLAYER_0:
 				# Check for scenario
@@ -252,8 +274,7 @@ class TicTacToe:
 						col = random.choice((0, 2))
 						valid_move = self.checkValidMove(row, col)
 					return row, col
-
-			# Check for second edge-case: see board [[ ,X, ], [ ,O, ], [X, , ]]
+			# Check for The Big L edge-case: see board [[ ,X, ], [ ,O, ], [X, , ]]
 			# In this scenario, bot loses if it selects (2, 1).  Avoid this (or rotated) scenarios.
 			if self.board[1][1] == bot_icon:
 				if self.board[0][1] != self.board[1][1] != self.board[2][1] != self.board[0][1]:
@@ -311,11 +332,12 @@ class TicTacToe:
 		return row, col
 
 	def resetGame(self) -> None:
-		"""Resets the board and game state, typically at the end of a game.
+		"""Resets the board, history and game state, typically at the end of a game.
 		Takes no arguments and makes no return.
 		"""
 
 		self.board = self.emptyBoard()
+		self.move_history = []
 		self.game_state = self.GAME_IN_PROGRESS
 
 

--- a/test_TicTacToe.py
+++ b/test_TicTacToe.py
@@ -294,6 +294,7 @@ def test_bot_avoids_double_middle_trap(tic_tac_toe):
         [(2, 1), (1, 1), (1, 0), (0, 2)],
         [(2, 1), (0, 2), (1, 0), (1, 1)]
     ]
+    # Run several times to account for randomness in bot decisions
     for _ in range(0, 10):
         for scenario in scenarios_to_check:
             # Initialize empty board
@@ -304,7 +305,9 @@ def test_bot_avoids_double_middle_trap(tic_tac_toe):
             tic_tac_toe.updateBoard(scenario[2][0], scenario[2][1], tic_tac_toe.PLAYER_0)
             # let the bot move once
             move = tic_tac_toe.botMove(tic_tac_toe.PLAYER_1)
+            # move should NOT be the center
             assert move != (1, 1)
+            # move SHOULD be a corner (besides the trap corner, see next assert)
             assert (move[0] + move[1]) % 2 == 0
             tic_tac_toe.updateBoard(move[0], move[1], tic_tac_toe.PLAYER_1)
             # check that the bot successfully avoided the trap

--- a/test_TicTacToe.py
+++ b/test_TicTacToe.py
@@ -279,3 +279,34 @@ def test_updatePlayerIcons_assigns_icons(tic_tac_toe: TicTacToe.TicTacTerminal):
         tic_tac_toe.updatePlayerIcons(icon1, icon2)
         assert tic_tac_toe.PLAYER_0_ICON == icon1
         assert tic_tac_toe.PLAYER_1_ICON == icon2
+
+
+def test_bot_avoids_double_middle_trap(tic_tac_toe):
+    # cases that can trap the bot into a loss,
+    # in the format (move1, move2, move3, move_to_avoid)
+    scenarios_to_check = [
+        [(0, 1), (1, 1), (1, 0), (2, 2)],
+        [(0, 1), (2, 2), (1, 0), (1, 1)],
+        [(0, 1), (1, 1), (1, 2), (2, 0)],
+        [(0, 1), (2, 0), (1, 2), (1, 1)],
+        [(2, 1), (1, 1), (1, 2), (0, 0)],
+        [(2, 1), (0, 0), (1, 2), (1, 1)],
+        [(2, 1), (1, 1), (1, 0), (0, 2)],
+        [(2, 1), (0, 2), (1, 0), (1, 1)]
+    ]
+    for _ in range(0, 10):
+        for scenario in scenarios_to_check:
+            # Initialize empty board
+            tic_tac_toe.board = tic_tac_toe.emptyBoard()
+            # simulate the scenario
+            tic_tac_toe.updateBoard(scenario[0][0], scenario[0][1], tic_tac_toe.PLAYER_0)
+            tic_tac_toe.updateBoard(scenario[1][0], scenario[1][1], tic_tac_toe.PLAYER_1)
+            tic_tac_toe.updateBoard(scenario[2][0], scenario[2][1], tic_tac_toe.PLAYER_0)
+            # let the bot move once
+            move = tic_tac_toe.botMove(tic_tac_toe.PLAYER_1)
+            assert move != (1, 1)
+            assert (move[0] + move[1]) % 2 == 0
+            tic_tac_toe.updateBoard(move[0], move[1], tic_tac_toe.PLAYER_1)
+            # check that the bot successfully avoided the trap
+            assert tic_tac_toe.board[scenario[3][0]][scenario[3][1]] != tic_tac_toe.PLAYER_1
+            tic_tac_toe.move_history = []


### PR DESCRIPTION
Shortly after the most recent round of bot improvements, a strategy was discovered that resulted in winning against the bot 30-50% of the time.  The bot has been upgraded to defend against this strategy, while maintaining that sense of unpredictability we all know and love. Minor updates to some comments while I was in the neighborhood.

This also uncovered a bug with TicTacToe.move_history, specifically, the move history was retained over the course of several games, causing other bot bugs and would have potentially caused crashes with planned future features (like undo move).  This was fixed by adding a line to resetGame that resets the move history along with the board and game state.

A test was added to pyTest to ensure the bot continues to avoid the trap that started this whole thing in the first place (it looks complicated but takes all of 0.03 seconds to run and adds 0.00 seconds to running the entire test suite).

I feel like I did a pretty good job staying on task with this one, all of those things were fairly closely related! :D